### PR TITLE
Add pascalize to create PascalCase for class names

### DIFF
--- a/can-string-test.js
+++ b/can-string-test.js
@@ -54,3 +54,20 @@ QUnit.test('string.hyphenate', function (assert) {
 	text = string.hyphenate('dataNode');
 	assert.equal(text, 'data-node');
 });
+
+QUnit.test('string.pascalize', function (assert) {
+	var text = string.pascalize(0);
+	assert.equal(text, '0', '0 value properly rendered');
+	text = string.pascalize(null);
+	assert.equal(text, '', 'null value returns empty string');
+	text = string.pascalize();
+	assert.equal(text, '', 'undefined returns empty string');
+	text = string.pascalize(NaN);
+	assert.equal(text, '', 'NaN returns empty string');
+	text = string.pascalize('baz-bar');
+	assert.equal(text, 'BazBar');
+	text = string.pascalize('barNode');
+	assert.equal(text, 'BarNode');
+	text = string.pascalize('bar');
+	assert.equal(text, 'Bar');
+});

--- a/can-string.js
+++ b/can-string.js
@@ -98,6 +98,22 @@ var string = {
 			});
 	},
 	/**
+	 * @function can-string.pascalize pascalize
+	 * @signature `string.pascalize(s)`
+	 * @param  {String} str   the string in hyphen case | camelCase
+	 * @return {String}       the supplied string with hyphens | camelCase converted to PascalCase
+	 *
+	 * ```js
+	 * var string = require("can-string");
+	 *
+	 * console.log(string.pascalize("fooBar")); // -> "FooBar"
+	 * console.log(string.pascalize("baz-bar")); // -> "BazBar"
+	 * ```
+	 */
+	pascalize: function (str) {
+		return string.capitalize(string.camelize(str));
+	},
+	/**
 	 * @function can-string.underscore underscore
 	 * @signature `string.underscore(s)`
 	 * @param  {String} str   a string in camelCase

--- a/can-string.md
+++ b/can-string.md
@@ -19,4 +19,5 @@ string.capitalize("foo")    //-> "Foo"
 string.esc("<div>foo</div>")//-> "&lt;div&gt;foo&lt;/div&gt;"
 string.hyphenate("fooBar")  //-> "foo-bar"
 string.underscore("fooBar") //-> "foo_bar"
+string.pascalize("foo-bar") //-> "FooBar"
 ```


### PR DESCRIPTION
For the upcoming CanJS6 with classes for us to generate class names based on tags for upgrades, we need a way to convert `hyphen-case` to `PascalCase`.

```
my-list -> MyList
or
myList -> MyList
```